### PR TITLE
fribidi 1.0.16 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,11 @@ build:
     - {{ pin_subpackage('fribidi', max_pin='x.x') }}
 
 requirements:
-  host:
-    - meson
-    - ninja-base
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - meson
+    - ninja-base
     - pkg-config  # [unix]
 
 test:
@@ -46,3 +45,5 @@ extra:
   recipe-maintainers:
     - msarahan
     - mariusvniekerk
+  skip-lints:
+    - python_build_tools_in_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,11 +15,12 @@ build:
     - {{ pin_subpackage('fribidi', max_pin='x.x') }}
 
 requirements:
+  host:
+    - meson
+    - ninja-base
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - meson
-    - ninja-base
     - pkg-config  # [unix]
 
 test:
@@ -30,6 +31,7 @@ about:
   home: https://github.com/fribidi/fribidi
   license: LGPL-2.1
   license_file: COPYING
+  license_family: GPL
   summary: The Free Implementation of the Unicode Bidirectional Algorithm.
   description: |
     One of the missing links stopping the penetration of free software in Middle

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1b1cde5b235d40479e91be2f0e88a309e3214c8ab470ec8a2744d82a5a9ea05c
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('fribidi', max_pin='x.x') }}
 
@@ -24,8 +24,6 @@ requirements:
 
 test:
   commands:
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
     - fribidi -h
 
 about:


### PR DESCRIPTION
fribidi 1.0.16 

**Destination channel:** Defaults

### Links

- [PKG-15120]
- dev_url:        https://github.com/fribidi/fribidi/tree/v1.0.16
- conda_forge:    n/a
- pypi:           https://pypi.org/project/fribidi/1.0.16
- pypi inspector: https://inspector.pypi.io/project/fribidi/1.0.16

### Explanation of changes:

- new build number
- remove `conda inspect` test commands which fail when tested against the `anaconda` metapackage


[PKG-15120]: https://anaconda.atlassian.net/browse/PKG-15120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ